### PR TITLE
Support flags for Docker Machine/Docker Compose installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ The variables we can use in this role.
 |name|description|default|
 |---|---|---|
 |docker_installscript_tmppath|Tmporary path for downloaded script to install Docker Engine.|/tmp/docker_install.sh|
+|docker_machine_is_installed|Whether Docker Machine is installed. This value isn't valid on OSX.|True|
 |docker_machine_download_url|Download URL for Docker Machine binary. Different architecture/version has different URL.|https://github.com/docker/machine/releases/download/v0.6.0/docker-machine-Linux-x86_64|
 |docker_machine_sha256|SHA256 signature of Docker Machine binary. This is used for idempotency.|6c383c4716985db2d7ae7e1689cc4acee0b23284e6e852d6bc59011696ca734a|
 |docker_machine_bin_path|Path Docker Machine binary is put.|/usr/local/bin/docker-machine|
+|docker_compose_is_installed|Whether Docker Compose is installed. This value isn't valid on OSX.|True|
 |docker_compose_download_url|Download URL for Docker Compose binary. Different architecture/version has different URL.|https://github.com/docker/compose/releases/download/1.6.2/docker-compose-Linux-x86_64|
 |docker_compose_sha256|SHA256 signature of Docker Compose binary. This is used for idempotency.|7c453a3e52fb97bba34cf404f7f7e7913c86e2322d612e00c71bd1588587c91e|
 |docker_compose_bin_path|Path Docker Compose binary is put.|/usr/local/bin/docker-compose|
@@ -52,7 +54,7 @@ Test on local Docker host
 -------------------------
 
 This project run tests on Travis CI, but we can also run then on local Docker host.
-Please check `install`, `before_script`, and `script` sections of `.travis.yml`. 
+Please check `install`, `before_script`, and `script` sections of `.travis.yml`.
 We can use same steps of them for local Docker host.
 
 Local requirements are as follows.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,11 @@
 ---
 # defaults file for docker_toolbox
 docker_installscript_tmppath: "/tmp/docker_install.sh"
+docker_machine_is_installed: "True"
 docker_machine_download_url: "https://github.com/docker/machine/releases/download/v0.6.0/docker-machine-Linux-x86_64"
 docker_machine_sha256: "6c383c4716985db2d7ae7e1689cc4acee0b23284e6e852d6bc59011696ca734a"
 docker_machine_bin_path: "/usr/local/bin/docker-machine"
+docker_compose_is_installed: "True"
 docker_compose_download_url: "https://github.com/docker/compose/releases/download/1.6.2/docker-compose-Linux-x86_64"
 docker_compose_sha256: "7c453a3e52fb97bba34cf404f7f7e7913c86e2322d612e00c71bd1588587c91e"
 docker_compose_bin_path: "/usr/local/bin/docker-compose"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -22,39 +22,43 @@
   shell: "sh {{ docker_installscript_tmppath }}"
   become: yes
   when: which_docker.rc != 0
-- name: Install Docker Machine
-  get_url: url="{{ docker_machine_download_url }}" checksum="sha256:{{ docker_machine_sha256 }}" dest="{{ docker_machine_bin_path }}" mode="0755"
-  become: yes
-  when: "{{ ansible_python_version | version_compare('2.7.9', '>=') }}"
-# get_url module on Python(< 2.7.9) cause SSL error
 - block:
-    - name: Check whether Docker Machine exists
-      stat: path="{{ docker_machine_bin_path }}"
-      register: st_result_docker_machine
-      changed_when: no
-    - name: Download Docker Machine binary with curl
-      command: "curl {{ docker_machine_download_url }} -o {{ docker_machine_bin_path }}"
-      become: yes
-      when: not st_result_docker_machine.stat.exists
-    - name: Make Docker Machine binary executable
-      file: path="{{ docker_machine_bin_path }}" mode="0755"
-      become: yes
-  when: "{{ ansible_python_version | version_compare('2.7.9', '<') }}"
-- name: Install Docker Compose
-  get_url: url="{{ docker_compose_download_url }}" checksum="sha256:{{ docker_compose_sha256 }}" dest="{{ docker_compose_bin_path }}" mode="0755"
-  become: yes
-  when: "{{ ansible_python_version | version_compare('2.7.9', '>=') }}"
-# get_url module on Python(< 2.7.9) cause SSL error
+  - name: Install Docker Machine
+    get_url: url="{{ docker_machine_download_url }}" checksum="sha256:{{ docker_machine_sha256 }}" dest="{{ docker_machine_bin_path }}" mode="0755"
+    become: yes
+    when: "{{ ansible_python_version | version_compare('2.7.9', '>=') }}"
+  # get_url module on Python(< 2.7.9) cause SSL error
+  - block:
+      - name: Check whether Docker Machine exists
+        stat: path="{{ docker_machine_bin_path }}"
+        register: st_result_docker_machine
+        changed_when: no
+      - name: Download Docker Machine binary with curl
+        command: "curl {{ docker_machine_download_url }} -o {{ docker_machine_bin_path }}"
+        become: yes
+        when: not st_result_docker_machine.stat.exists
+      - name: Make Docker Machine binary executable
+        file: path="{{ docker_machine_bin_path }}" mode="0755"
+        become: yes
+    when: "{{ ansible_python_version | version_compare('2.7.9', '<') }}"
+  when: "{{ docker_machine_is_installed }}"
 - block:
-    - name: Check whether Docker Compose exists
-      stat: path="{{ docker_compose_bin_path }}"
-      register: st_result_docker_compose
-      changed_when: no
-    - name: Download Docker Compose binary with curl
-      command: "curl {{ docker_compose_download_url }} -o {{ docker_compose_bin_path }}"
-      become: yes
-      when: not st_result_docker_compose.stat.exists
-    - name: Make Docker Compose binary executable
-      file: path="{{ docker_compose_bin_path }}" mode="0755"
-      become: yes
-  when: "{{ ansible_python_version | version_compare('2.7.9', '<') }}"
+  - name: Install Docker Compose
+    get_url: url="{{ docker_compose_download_url }}" checksum="sha256:{{ docker_compose_sha256 }}" dest="{{ docker_compose_bin_path }}" mode="0755"
+    become: yes
+    when: "{{ ansible_python_version | version_compare('2.7.9', '>=') }}"
+  # get_url module on Python(< 2.7.9) cause SSL error
+  - block:
+      - name: Check whether Docker Compose exists
+        stat: path="{{ docker_compose_bin_path }}"
+        register: st_result_docker_compose
+        changed_when: no
+      - name: Download Docker Compose binary with curl
+        command: "curl {{ docker_compose_download_url }} -o {{ docker_compose_bin_path }}"
+        become: yes
+        when: not st_result_docker_compose.stat.exists
+      - name: Make Docker Compose binary executable
+        file: path="{{ docker_compose_bin_path }}" mode="0755"
+        become: yes
+    when: "{{ ansible_python_version | version_compare('2.7.9', '<') }}"
+  when: "{{ docker_compose_is_installed }}"


### PR DESCRIPTION
In default, they are installed. But hosts for only containers mayn't
need them.